### PR TITLE
make getrandbits(0) not change state

### DIFF
--- a/gf2bv/crypto/mt.py
+++ b/gf2bv/crypto/mt.py
@@ -65,6 +65,8 @@ class MersenneTwister:
             k = self.w
         if k < 0:
             raise ValueError("number of bits cannot be negative")
+        if k == 0:
+            return 0
         if k <= self.w:
             return self._getrandbits_word(k)
         words = (k - 1) // self.w + 1


### PR DESCRIPTION
Currently getrandbits(0) calls getrandbits_32 and return value >> 32 which is 0. But this changes internal state while the real implementation doesn't.
```
>>> import random
>>> random.seed(1234)
>>> random.getrandbits(32)
4150886329
>>> random.seed(1234)
>>> random.getrandbits(0)
0
>>> random.getrandbits(32)
4150886329
```